### PR TITLE
Enable publish provider to allow endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ What is this module capable of doing?
  * Enabling/starting or disabling the API
  * Managing the init.d service file
  * Managing apt mirrors, repositories, snapshots and publications
- 
+
 The aptly service will listen on port you configure (example: 8080) on every interfaces (configurable)
 using the `aptly serve -listen=":8080"` command.
 
@@ -659,6 +659,12 @@ Default: `undef`
 Distribution name to publish.
 
 Default: `"${::lsbdistcodename}-${name}"`
+
+##### `endpoint`
+
+The endpoint to publish to.
+
+Default: `undef`
 
 ## Limitations
 

--- a/lib/puppet/provider/aptly_publish/cli.rb
+++ b/lib/puppet/provider/aptly_publish/cli.rb
@@ -9,12 +9,14 @@ Puppet::Type.type(:aptly_publish).provide(:cli) do
   def create
     Puppet.info("Publishing Aptly #{resource[:source_type]} #{name}")
 
+    arguments = resource[:endpoint] ? [name, "#{resource[:endpoint]}:#{name}"] : [name]
+
     Puppet_X::Aptly::Cli.execute(
       uid: resource[:uid],
       gid: resource[:gid],
       object: :publish,
       action: resource[:source_type],
-      arguments: [name],
+      arguments: arguments,
       flags: { 'distribution' => resource[:distribution], 'config' => resource[:config_filepath] }
     )
   end
@@ -22,18 +24,22 @@ Puppet::Type.type(:aptly_publish).provide(:cli) do
   def destroy
     Puppet.info("Destroying Aptly Publish #{name}")
 
+    publish_name = resource[:endpoint] ? "#{resource[:endpoint]}:#{name}" : [name]
+
     Puppet_X::Aptly::Cli.execute(
       uid: resource[:uid],
       gid: resource[:gid],
       object: :publish,
       action: 'drop',
-      arguments: [name],
+      arguments: [resource[:distribution], publish_name],
       flags: { 'force-drop' => resource[:force] ? 'true' : 'false', 'config' => resource[:config_filepath] }
     )
   end
 
   def exists?
     Puppet.debug("Check if #{name} exists")
+
+    publish_name = resource[:endpoint] ? "#{resource[:endpoint]}:#{name}" : [name]
 
     Puppet_X::Aptly::Cli.execute(
       uid: resource[:uid],
@@ -42,6 +48,6 @@ Puppet::Type.type(:aptly_publish).provide(:cli) do
       action: 'list',
       flags: { 'raw' => 'true', 'config' => resource[:config_filepath] },
       exceptions: false
-    ).lines.map(&:chomp).include? name
+    ).lines.map(&:chomp).include? "#{publish_name} #{resource[:distribution]}"
   end
 end

--- a/lib/puppet/type/aptly_publish.rb
+++ b/lib/puppet/type/aptly_publish.rb
@@ -36,6 +36,10 @@ Puppet::Type.newtype(:aptly_publish) do
     defaultto :snapshot
   end
 
+  newparam(:endpoint) do
+    desc 'The publication endpoint'
+  end
+
   newparam(:distribution) do
     desc 'Distribution name to publish'
     validate do |value|

--- a/manifests/publish.pp
+++ b/manifests/publish.pp
@@ -9,6 +9,7 @@ define aptly::publish (
   $gid             = '450',
   $config_filepath = '/etc/aptly.conf',
   $distribution    = "${::lsbdistcodename}-${name}",
+  $endpoint        = undef,
 ) {
   validate_string(
     $source_type,
@@ -22,6 +23,7 @@ define aptly::publish (
     config_filepath => $config_filepath,
     source_type     => $source_type,
     distribution    => $distribution,
+    endpoint        => $endpoint,
     notify          => Class['aptly::service'],
   }
 }


### PR DESCRIPTION
This change allows `aptly::publish` to be used with filesystem endpoints.